### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cola/cluster/master.py
+++ b/cola/cluster/master.py
@@ -222,7 +222,7 @@ class Master(object):
                         for job in self.job_tracker.running_jobs:
                             self.job_tracker.remove_worker(job, worker)
                         
-                # if continously connect for more than 10 min
+                # if continuously connect for more than 10 min
                 elif info.continous_register >= CONTINOUS_HEARTBEAT:
                     if info.status != RUNNING:
                         info.status = RUNNING

--- a/cola/core/bloomfilter/__init__.py
+++ b/cola/core/bloomfilter/__init__.py
@@ -87,7 +87,7 @@ class BloomFilter(HashType):
 
     def _optimal_size(self, capacity, error):
         """Calculates minimum number of bits in filter array and
-        number of hash functions given a number of enteries (maximum)
+        number of hash functions given a number of entries (maximum)
         and the desired error rate (false positives).
         
         Example:

--- a/cola/core/opener.py
+++ b/cola/core/opener.py
@@ -129,7 +129,7 @@ class MechanizeOpener(Opener):
     def open(self, url, data=None, timeout=None):
         # check if gzip by
         # br.response().info().dict.get('content-encoding') == 'gzip'
-        # experimently add `self.br.set_handle_gzip(True)` to handle
+        # experimentally add `self.br.set_handle_gzip(True)` to handle
         self._clear_content()
         if timeout is None:
             timeout = self._default_timout


### PR DESCRIPTION
There are small typos in:
- cola/cluster/master.py
- cola/core/bloomfilter/__init__.py
- cola/core/opener.py

Fixes:
- Should read `experimentally` rather than `experimently`.
- Should read `entries` rather than `enteries`.
- Should read `continuously` rather than `continously`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md